### PR TITLE
1.0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Fix hover state colors for search filter dropdown items
 * Make search results dropdown a little more prominent / easier to view when open
 * Added additional styling for admin-only sections
+* Fix background color and icon spacing of nav pills in post revision modal
 
 ### 1.0.9
 * Fix link and category badge styling of a quoted post in a PM

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Fix styling for timegap: notification shown under a post that has a large break between it and the preceding post
 * Fix link styling in certain alerts
 * Fix font color of search results title in dropdown
+* Fix hover state colors for search filter dropdown items
 * Make search results dropdown a little more prominent / easier to view when open
 
 ### 1.0.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Fix font color of search results title in dropdown
 * Fix hover state colors for search filter dropdown items
 * Fix icon color on post composer fullscreen and minimise buttons
+* Fix overflow issue on topic timeline scroller
 * Make search results dropdown a little more prominent / easier to view when open
 * Added additional styling for admin-only sections
 * Fix background color and icon spacing of nav pills in post revision modal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Fix link styling in certain alerts
 * Fix font color of search results title in dropdown
 * Fix hover state colors for search filter dropdown items
+* Fix icon color on post composer fullscreen and minimise buttons
 * Make search results dropdown a little more prominent / easier to view when open
 * Added additional styling for admin-only sections
 * Fix background color and icon spacing of nav pills in post revision modal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### Changelog
 ### 1.0.10
 * Fix styling for timegap: notification shown under a post that has a large break between it and the preceding post
+* Fix link styling in certain alerts
 
 ### 1.0.9
 * Fix link and category badge styling of a quoted post in a PM

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Fix font color of search results title in dropdown
 * Fix hover state colors for search filter dropdown items
 * Make search results dropdown a little more prominent / easier to view when open
+* Added additional styling for admin-only sections
 
 ### 1.0.9
 * Fix link and category badge styling of a quoted post in a PM

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Fix styling for timegap: notification shown under a post that has a large break between it and the preceding post
 * Fix link styling in certain alerts
 * Fix font color of search results title in dropdown
+* Make search results dropdown a little more prominent / easier to view when open
 
 ### 1.0.9
 * Fix link and category badge styling of a quoted post in a PM

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Fix hover state colors for search filter dropdown items
 * Fix icon color on post composer fullscreen and minimise buttons
 * Fix overflow issue on topic timeline scroller
+* Uniform sizing of navigation/filter dropdowns
 * Make search results dropdown a little more prominent / easier to view when open
 * Added additional styling for admin-only sections
 * Fix background color and icon spacing of nav pills in post revision modal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fix icon color on post composer fullscreen and minimise buttons
 * Fix overflow issue on topic timeline scroller
 * Uniform sizing of navigation/filter dropdowns
+* Fix styling os sticky header when bulk updating topics
 * Make search results dropdown a little more prominent / easier to view when open
 * Added additional styling for admin-only sections
 * Fix background color and icon spacing of nav pills in post revision modal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ### Changelog
+### 1.0.10
+* Fix styling for timegap: notification shown under a post that has a large break between it and the preceding post
+
 ### 1.0.9
 * Fix link and category badge styling of a quoted post in a PM
 * Restyled edit topic title icon to make it easier to click on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### 1.0.10
 * Fix styling for timegap: notification shown under a post that has a large break between it and the preceding post
 * Fix link styling in certain alerts
+* Fix font color of search results title in dropdown
 
 ### 1.0.9
 * Fix link and category badge styling of a quoted post in a PM

--- a/waypoint.light.user.css
+++ b/waypoint.light.user.css
@@ -111,8 +111,25 @@ textarea {
 }
 .search-menu .search-link:focus,
 .search-menu .search-link:hover {
-	background-color: var(--primary);
-	color: var(--tertiary-medium);
+	background-color: var(--tertiary-medium);
+	color: var(--primary);
+}
+
+.search-menu .search-link:focus .badge-wrapper .badge-category .category-name,
+.search-menu .search-link:hover .badge-wrapper .badge-category .category-name,
+.search-menu .results .search-menu-assistant .search-link:hover,
+.search-menu .results .search-menu-assistant .search-link:focus,
+.search-menu .results .search-menu-initial-options .search-link:hover .label-suffix,
+.search-menu .results .search-menu-initial-options .search-link:focus .label-suffix,
+.search-menu .results .search-menu-initial-options .search-link:hover .extra-hint,
+.search-menu .results .search-menu-initial-options .search-link:focus .extra-hint {
+	color: var(--primary);
+}
+.search-menu .search-link:focus .topic-title,
+.search-menu .search-link:hover .topic-title,
+.search-menu .search-link:focus .blurb,
+.search-menu .search-link:hover .blurb {
+	color: var(--primary-very-high);
 }
 .search-menu .search-link .topic-title {
 	color: var(--tertiary-medium);

--- a/waypoint.light.user.css
+++ b/waypoint.light.user.css
@@ -2761,3 +2761,217 @@ div.education {
 	color: var(--primary-high);
 }
 }
+
+@-moz-document url-prefix("https://forums.halowaypoint.com/admin/badges") {
+	.btn-primary[href] {
+		color: var(--primary);
+	}
+	.admin-badges .badges {
+		display: grid;
+		grid-template-columns: auto 1fr;
+		grid-template-rows: auto 1fr;
+		grid-gap: 20px;
+		grid-column-gap: 10px;
+	}
+	.admin-badges .badges .badges-header {
+		grid-column-start: 1;
+		grid-column-end: 3;
+		grid-row-start: 1;
+		grid-row-end: 2;
+		display: flex;
+		align-items: center;
+		flex: 1 0 100%;
+	}
+	.admin-badges .badges .content-list {
+		flex: unset;
+		grid-column-start: 1;
+		grid-column-end: 2;
+		grid-row-start: 2;
+		grid-row-end: 3;
+	}
+	.admin-badges .current-badge,
+	.award-badge {
+		grid-column-start: 2;
+		grid-column-end: 3;
+		background: var(--primary);
+		padding: 2em;
+		background-color: var(--primary);
+		margin: 0 0 20px;
+		border-top: 2px solid var(--tertiary-medium);
+		border-bottom: 3px solid var(--tertiary-medium);
+	}
+	.content-list {
+		float: none;
+		width: auto;
+	}
+	.content-body {
+		float: none;
+		width: inherit;
+	}
+	
+	.admin-badges .badges .current-badges {
+		background: var(--primary);
+		border-bottom: 3px solid var(--tertiary-medium);
+		flex: auto;
+	}
+	
+	.admin-badges .content-list .admin-badge-list {
+		border-left: 0;
+		border-bottom: 0;
+		border-right: 0;
+	}
+	.admin-badges .badges-header {
+		border-bottom: none;
+	}
+	.admin-intro {
+		margin-left: 0;
+		margin-top: 40px;
+		padding: 2em;
+	}
+	.admin-badge-list {
+		background-color: transparent;
+		border-left: 0;
+	}
+	.admin-badge-list-item:last-child {
+		border-bottom: 0;
+	}
+	.content-list ul li {
+		border-bottom: 0;
+		margin-bottom: 5px;
+	}
+	.content-list ul li a.active,
+	.content-list ul li a:hover {
+		background-color: rgba(0, 0, 0, 0.05);
+	}
+	.user-badge {
+		color: var(--secondary);
+	}
+	
+	.content-list ul li a.active .user-badge {
+		color: var(--tertiary-medium);
+	}
+	.award-badge {
+		max-width: initial;
+		float: none;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+	} 
+	.award-badge .badge-preview {
+		background-color: transparent;
+		border: 1px solid var(--tertiary-medium);
+	}
+	}
+	
+	@-moz-document url-prefix("https://forums.halowaypoint.com/admin/customize/user_fields") {
+	.user-field.ember-view {
+		background: var(--primary);
+		border-bottom: 3px solid var(--tertiary-medium);
+	}
+	}
+	
+	@-moz-document url-prefix("https://forums.halowaypoint.com/admin/customize/permalinks") {
+	.permalink-form {
+		background: var(--primary);
+	}
+	}
+	
+	@-moz-document url-prefix("https://forums.halowaypoint.com/admin/customize/site_texts") {
+	.site-texts .site-text {
+		background: var(--primary);
+		border-bottom: 3px solid var(--tertiary-medium);
+		padding: 1em;
+	}
+	.site-texts .site-text h3 {
+		font-size: var(--font-up-1);
+		font-weight: 500;
+		color: var(--tertiary-medium);
+	}
+	.site-texts .site-text .site-text-value {
+		color: var(--secondary);
+	}
+	}
+	
+	@-moz-document url-prefix("https://forums.halowaypoint.com/admin/customize/colors") {
+	.content-list h3 {
+		color: var(--secondary);
+	}
+	.admin-customize .content-list ul {
+		background: var(--primary);
+	}
+	.content-list ul li:first-of-type,
+	.content-list ul li {
+		border-color: var(--primary-high);
+	}
+	.content-list ul li a {
+		color: var(--secondary);
+	}
+	.content-list ul li a.active {
+		background: var(--quaternary);
+		color: var(--primary);
+	}
+	.admin-customize .color-schemes li a.active .d-icon {
+		color: var(--primary);
+	}
+	}
+	
+	@-moz-document url-prefix("https://forums.halowaypoint.com/admin/customize/themes") {
+	.admin-intro {
+		display: inline-flex;
+		width: 100%;
+		justify-content: center;
+		margin-left: 0;
+		margin-top: 0;
+		background: white;
+		padding: 1em;
+		max-width: 60%;
+		vertical-align: top;
+	}
+	.admin-controls .nav-pills {
+		margin-bottom: 5px;
+	}
+	.popular-theme-item .popular-theme-name a {
+		color: var(--tertiary-medium);
+	}
+	.admin-customize .themes-list-container .themes-list-item .info .name,
+	.admin-customize .themes-list-container .themes-list-item span.empty {
+		color: var(--secondary);
+	}
+	.admin-customize .themes-list-container .themes-list-item:not(.inactive-indicator):not(.selected):hover {
+		background: var(--primary);
+	}
+	.admin-customize .current-style .nav-pills li a.blank:not(.active) {
+		color: var(--secondary);
+	}
+	.admin-customize .current-style .edit-main-nav .nav-pills > li a.active,
+	.admin-customize .current-style .nav-pills li a.blank:not(.active):hover {
+		color: var(--primary);
+	}
+	}
+	
+	@-moz-document url-prefix("https://forums.halowaypoint.com/admin/site_settings/") {
+	.settings .setting.overridden.string input[type="text"], 
+	.settings .setting.overridden.string input[type="password"], 
+	.settings .setting.overridden.string textarea {
+		background: var(--primary);
+	}
+	.settings .setting.overridden h3 {
+		color: var(--tertiary-medium);
+		font-weight: 500;
+	}
+	}
+	
+	@-moz-document url-prefix("https://forums.halowaypoint.com/admin/api") {
+	.admin-api-keys .api-key {
+		background: var(--primary);
+		padding: 0.5em 1em;
+		margin-top: 1em;
+		border-bottom: 3px solid var(--tertiary-medium);
+	}
+	}
+	
+	@-moz-document url-prefix("https://forums.halowaypoint.com/admin/email") {
+	.admin-controls {
+		margin-top: 1em;
+	}
+	}

--- a/waypoint.light.user.css
+++ b/waypoint.light.user.css
@@ -100,7 +100,6 @@ textarea {
 }
 
 /* Search */
-.halo-custom-navigation-search .search-menu,
 .halo-custom-navigation-search .search-menu .results {
 	background-color: var(--primary);
 	border-bottom: 3px solid var(--tertiary-medium);

--- a/waypoint.light.user.css
+++ b/waypoint.light.user.css
@@ -367,6 +367,9 @@ textarea {
 #reply-control .reply-to .composer-controls .btn {
 	border-radius: 0;
 }
+#reply-control .reply-to .composer-controls .d-icon {
+	color: var(--primary);
+}
 
 .select-kit.single-select.dropdown-select-box .select-kit-row.is-highlighted .texts .name,
 .select-kit.single-select.dropdown-select-box .select-kit-row.is-selected .texts .name,

--- a/waypoint.light.user.css
+++ b/waypoint.light.user.css
@@ -276,6 +276,16 @@ textarea {
 	margin-right: 5px;
 }
 
+.sticky-header .topic-list-header {
+	background: var(--tertiary-medium);
+}
+.topic-list .topic-list-data.bulk-select {
+	text-align: center;
+}
+.sticky-header .topic-list-header .topic-list-data {
+	color: var(--primary);
+}
+
 /* Posting editor */
 #reply-control {
 	background-color: var(--primary);

--- a/waypoint.light.user.css
+++ b/waypoint.light.user.css
@@ -102,7 +102,9 @@ textarea {
 /* Search */
 .halo-custom-navigation-search .search-menu,
 .halo-custom-navigation-search .search-menu .results {
-	background-color: var(--primary)
+	background-color: var(--primary);
+	border-bottom: 3px solid var(--tertiary-medium);
+	box-shadow: rgba(0, 0, 0, 0.1) 0px 4px 12px;
 }
 .search-menu .results .label-suffix {
 	color: var(--primary-low-mid-or-secondary-high);

--- a/waypoint.light.user.css
+++ b/waypoint.light.user.css
@@ -112,6 +112,9 @@ textarea {
 	background-color: var(--primary);
 	color: var(--tertiary-medium);
 }
+.search-menu .search-link .topic-title {
+	color: var(--tertiary-medium);
+}
 
 /* Alert */
 .alert.alert-info {

--- a/waypoint.light.user.css
+++ b/waypoint.light.user.css
@@ -117,8 +117,12 @@ textarea {
 .alert.alert-info {
 	background-color: var(--tertiary-medium);
 }
-.alert.alert-info.clickable {
+.alert.alert-info.clickable,
+.alert.alert-info a {
 	color: var(--primary);
+}
+.alert.alert-info a {
+	text-decoration: underline;
 }
 
 /* User card */

--- a/waypoint.light.user.css
+++ b/waypoint.light.user.css
@@ -1,6 +1,6 @@
 /* ==UserStyle==
 @name           Waypoint Light
-@version        1.0.9
+@version        1.0.10
 @description    A customized light theme for Halo Waypoint.
 @updateURL      https://github.com/stickerboy/waypoint-light/raw/main/waypoint.light.user.css
 @namespace      stickerboy/waypoint-light
@@ -8,7 +8,7 @@
 @homepageURL    https://github.com/stickerboy/waypoint-light/
 @supportURL     https://github.com/stickerboy/waypoint-light/issues
 ==/UserStyle== */
-/* Version: 1.0.9 */
+/* Version: 1.0.10 */
 
 @-moz-document url-prefix("https://forums.halowaypoint.com/") {
 /* Global styling */

--- a/waypoint.light.user.css
+++ b/waypoint.light.user.css
@@ -520,10 +520,10 @@ summary:before {
 	margin-bottom: 9px;
 }
 
-
-
-
-
+.timeline-container .topic-timeline .timeline-scroller-content {
+    box-sizing: content-box;
+    overflow: visible;
+}
 
 /* Butons */
 .btn {

--- a/waypoint.light.user.css
+++ b/waypoint.light.user.css
@@ -231,6 +231,7 @@ textarea {
 #navigation-bar .navigation-toggle {
 	background-color: var(--primary);
 	border: 1px solid var(--secondary);
+	margin-bottom: 0;
 }
 .nav-pills > li > a {
 	color: var(--secondary);

--- a/waypoint.light.user.css
+++ b/waypoint.light.user.css
@@ -1104,11 +1104,14 @@ a.edit-topic::after {
 	margin-bottom: 20px;
 }
 .small-action .small-action-desc.timegap {
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	font-size: var(--font-up-1);
-	padding: 0.8em 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: var(--font-0);
+    padding: 0.6em 0.8em;
+    margin-bottom: -1px;
+    color: var(--primary);
+    background-color: var(--tertiary-medium);
 }
 .time-gap .topic-avatar {
 	display: none;

--- a/waypoint.light.user.css
+++ b/waypoint.light.user.css
@@ -272,6 +272,9 @@ textarea {
 .nav-pills .drop li:focus a {
 	color: var(--primary);
 }
+.nav-pills > li a .d-icon {
+	margin-right: 5px;
+}
 
 /* Posting editor */
 #reply-control {
@@ -569,6 +572,9 @@ summary:before {
 }
 .modal.has-tabs .modal-tabs .modal-tab.is-active.single-tab {
 	color: var(--secondary);
+}
+.modal .nav {
+    background-color: transparent;
 }
 .bootbox.modal {
 	background-color: var(--primary);


### PR DESCRIPTION
* Fix styling for timegap: notification shown under a post that has a large break between it and the preceding post
* Fix link styling in certain alerts
* Fix font color of search results title in dropdown
* Fix hover state colors for search filter dropdown items
* Fix icon color on post composer fullscreen and minimise buttons
* Fix overflow issue on topic timeline scroller
* Uniform sizing of navigation/filter dropdowns
* Fix styling os sticky header when bulk updating topics
* Make search results dropdown a little more prominent / easier to view when open
* Added additional styling for admin-only sections
* Fix background color and icon spacing of nav pills in post revision modal